### PR TITLE
Lappish culture name list

### DIFF
--- a/Compatches/SWMH/00_cultures.txt
+++ b/Compatches/SWMH/00_cultures.txt
@@ -1660,7 +1660,7 @@ finno_ugric = {
 		modifier = default_culture_modifier
 	}
 	samoyed = { # AKA Bjarmian
-		graphical_culture = ugricgfx
+		graphical_culture = siberiangfx
 		color = { 0.3 0.75 0.75 }
 
 		male_names = {


### PR DESCRIPTION
I cleaned up the whitespace/indentation in the finno_ugric section of SWMH's 00_cultures.txt while I was at it, hence the larger diff.  Everybody in the group uses `ugricgfx` except for khanty & samoyed whom use `siberiangfx`.
